### PR TITLE
Add NewRelic API Client

### DIFF
--- a/newrelic/application_instances.go
+++ b/newrelic/application_instances.go
@@ -35,7 +35,7 @@ func (c *Client) ListInstances(applicationID int) ([]ApplicationInstance, error)
 		return nil, err
 	}
 
-	appInstances := &listInstancesResponse{}
-	_, err = c.do(req, appInstances)
-	return appInstances.Instances, err
+	var response listInstancesResponse
+	_, err = c.do(req, response)
+	return response.Instances, err
 }

--- a/newrelic/application_instances.go
+++ b/newrelic/application_instances.go
@@ -36,6 +36,6 @@ func (c *Client) ListInstances(applicationID int) ([]ApplicationInstance, error)
 	}
 
 	var response listInstancesResponse
-	_, err = c.do(req, response)
+	_, err = c.do(req, &response)
 	return response.Instances, err
 }

--- a/newrelic/application_instances.go
+++ b/newrelic/application_instances.go
@@ -1,0 +1,41 @@
+package newrelic
+
+import (
+	"fmt"
+)
+
+// ApplicationInstance represents a New Relic application instance.
+type ApplicationInstance struct {
+	ID                 int64              `json:"id"`
+	Host               string             `json:"host"`
+	HealthStatus       string             `json:"health_status"`
+	ApplicationSummary ApplicationSummary `json:"application_summary"`
+}
+
+// ApplicationSummary represents a rolling three-to-four-minute
+// average for application key values
+type ApplicationSummary struct {
+	InstanceCount int     `json:"instance_count"`
+	ResponseTime  float64 `json:"response_time"`
+	Throughput    float64 `json:"throughput"`
+	ErrorRate     float64 `json:"error_rate"`
+	ApdexScore    float64 `json:"apdex_score"`
+}
+
+type listInstancesResponse struct {
+	Instances []ApplicationInstance `json:"application_instances"`
+}
+
+// ListInstances returns a paginated list of instances associated with the given application.
+// The time range for summary data is the last 3-4 minutes.
+func (c *Client) ListInstances(applicationID int) ([]ApplicationInstance, error) {
+	path := fmt.Sprintf("v2/applications/%d/instances.json", applicationID)
+	req, err := c.newRequest("GET", path)
+	if err != nil {
+		return nil, err
+	}
+
+	appInstances := &listInstancesResponse{}
+	_, err = c.do(req, appInstances)
+	return appInstances.Instances, err
+}

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -1,0 +1,73 @@
+package newrelic
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const defaultBaseURL = "https://api.newrelic.com/"
+
+type transport struct {
+	transport http.RoundTripper
+	apiKey    string
+}
+
+func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Add("X-Api-Key", t.apiKey)
+	r.Header.Add("User-Agent", "newrelic_exporter;go")
+	return t.transport.RoundTrip(r)
+}
+
+// A Client manages communication with the NewRelic API
+type Client struct {
+	baseURL *url.URL
+	client  *http.Client
+}
+
+// NewClient returns an initialized NewRelic API client
+func NewClient(apiKey string) *Client {
+	baseURL, _ := url.Parse(defaultBaseURL)
+	return &Client{
+		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: time.Second * 10,
+			Transport: &transport{
+				transport: http.DefaultTransport,
+				apiKey:    apiKey,
+			},
+		},
+	}
+}
+
+func (c *Client) newRequest(method, path string) (*http.Request, error) {
+	url, err := c.baseURL.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, err
+}
+
+func (c *Client) do(req *http.Request, result interface{}) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(resp)
+
+	err = json.NewDecoder(resp.Body).Decode(result)
+	return resp, err
+}
+
+func closeResponse(resp *http.Response) {
+	if resp != nil {
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
Criado o cliente http para consumir as APIs do NewRelic. Foi criado a estrutura inicial e criado apenas um único método, o `ListInstances` que irá listar as instâncias de uma determinada aplicação do NewRelic.

refs https://github.com/ContaAzul/blackops/issues/1490
@ContaAzul/blackops 