### PR TITLE
Add config support to exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,31 @@
 
 Exports New Relic applications metrics data as prometheus metrics.
 
+### Configuration
+
+You must add New Relic applications that you want to export metrics in the `config.yml` file:
+```yaml
+applications:
+  - id: 31584797            #New Relic application ID
+    name: My Application    #New Relic application name
+```
+
 ### Running
 
 ```console
-./newrelic_exporter --api-key=${NEWRELIC_API_KEY}
+./newrelic_exporter --api-key=${NEWRELIC_API_KEY} --config=config.yml
 ```
 
 Or with docker:
 
 ```console
-docker run -p 9112:9112 -e "NEWRELIC_API_KEY=${NEWRELIC_API_KEY}" caninjas/newrelic_exporter
+docker run -p 9112:9112 -v /path/to/my/config.yml:/config.yml -e "NEWRELIC_API_KEY=${NEWRELIC_API_KEY}" caninjas/newrelic_exporter
 ```
 
 ### Flags
 
 Name    | Description
---------|---------------------------------------------
-addr    | Address to bind the server (default :9112)
+--------|---------------------------------------------------------
+addr    | Address to bind the server (default `:9112`)
 api-key | Your New Relic API key (required)
+config  | Your configuration file path (default `config.yml`)

--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,4 @@ applications:
     name: My Application
   - id: 31595724
     name: Another
+    

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,5 @@
+applications:
+  - id: 31584797
+    name: My Application
+  - id: 31595724
+    name: Another

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,3 @@ applications:
     name: My Application
   - id: 31595724
     name: Another
-    

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// Config represents the exporter's configuration
+// Config represents the exporter configuration
 type Config struct {
 	Applications []application `yaml:"applications,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,15 +17,15 @@ type application struct {
 	Name string `yaml:"name,omitempty"`
 }
 
-// Parse reads and parse a given file to a new Config
+// Parse reads and parse a given configuration file to a new Config
 func Parse(path string) Config {
 	var config Config
 
-	file, err := ioutil.ReadFile(path)
+	bts, err := ioutil.ReadFile(path)
 	if err != nil {
 		log.With("path", path).Fatalf("Failed to read configuration file: %v", err)
 	}
-	if err := yaml.Unmarshal(file, &config); err != nil {
+	if err := yaml.Unmarshal(bts, &config); err != nil {
 		log.With("path", path).Fatalf("Failed to unmarshall configuration file: %v", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"io/ioutil"
+
+	"github.com/prometheus/common/log"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// Config represents the exporter's configuration
+type Config struct {
+	Applications []application `yaml:"applications,omitempty"`
+}
+
+type application struct {
+	ID   int64  `yaml:"id,omitempty"`
+	Name string `yaml:"name,omitempty"`
+}
+
+// Parse reads and parse a given file to a new Config
+func Parse(path string) Config {
+	var config Config
+
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.With("path", path).Fatalf("Failed to read configuration file: %v", err)
+	}
+	if err := yaml.Unmarshal(file, &config); err != nil {
+		log.With("path", path).Fatalf("Failed to unmarshall configuration file: %v", err)
+	}
+
+	return config
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ContaAzul/newrelic_exporter/collector"
+	"github.com/ContaAzul/newrelic_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
@@ -12,9 +13,10 @@ import (
 )
 
 var (
-	version = "dev"
-	addr    = kingpin.Flag("addr", "Address to bind the server").Default(":9112").OverrideDefaultFromEnvar("SERVER_ADDR").String()
-	apiKey  = kingpin.Flag("api-key", "New Relic API key").OverrideDefaultFromEnvar("NEWRELIC_API_KEY").String()
+	version    = "dev"
+	addr       = kingpin.Flag("addr", "Address to bind the server").Default(":9112").OverrideDefaultFromEnvar("SERVER_ADDR").String()
+	apiKey     = kingpin.Flag("api-key", "New Relic API key").OverrideDefaultFromEnvar("NEWRELIC_API_KEY").String()
+	configFile = kingpin.Flag("config", "Configuration file path").Default("config.yml").OverrideDefaultFromEnvar("CONFIG_FILEPATH").String()
 )
 
 func main() {
@@ -28,7 +30,8 @@ func main() {
 		log.Fatal("You must provide your New Relic API key")
 	}
 
-	prometheus.MustRegister(collector.NewNewRelicCollector(*apiKey))
+	var config = config.Parse(*configFile)
+	prometheus.MustRegister(collector.NewNewRelicCollector(*apiKey, config))
 
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/newrelic/application_instances.go
+++ b/newrelic/application_instances.go
@@ -28,7 +28,7 @@ type listInstancesResponse struct {
 
 // ListInstances returns a paginated list of instances associated with the given application.
 // The time range for summary data is the last 3-4 minutes.
-func (c *Client) ListInstances(applicationID int) ([]ApplicationInstance, error) {
+func (c *Client) ListInstances(applicationID int64) ([]ApplicationInstance, error) {
 	path := fmt.Sprintf("v2/applications/%d/instances.json", applicationID)
 	req, err := c.newRequest("GET", path)
 	if err != nil {


### PR DESCRIPTION
Adicionado suporte a permitir configurar quais aplicações do NewRelic serão coletadas as métricas. 
Inicialmente foi adicionado o ID e nome como parâmetro por ser mais simples e fácil definir quais aplicações devem ser coletadas as métricas.

Modificado o `newRelicCollector` para já considerar os valores informados no arquivo de configuração.

refs https://github.com/ContaAzul/blackops/issues/1490
@ContaAzul/blackops 