### PR TITLE
Collect application summary data

### DIFF
--- a/newrelic/application.go
+++ b/newrelic/application.go
@@ -1,0 +1,31 @@
+package newrelic
+
+import (
+	"fmt"
+)
+
+// Application represents a New Relic application.
+type Application struct {
+	ID                 int64              `json:"id"`
+	HealthStatus       string             `json:"health_status"`
+	ApplicationSummary ApplicationSummary `json:"application_summary"`
+}
+
+type applicationResponse struct {
+	Application Application `json:"application"`
+}
+
+// ShowApplication returns a single Application, identified by ID. The time range for
+// summary data is the last 3-4 minutes.
+func (c *Client) ShowApplication(applicationID int64) (Application, error) {
+	var app Application
+	path := fmt.Sprintf("v2/applications/%d.json", applicationID)
+	req, err := c.newRequest("GET", path)
+	if err != nil {
+		return app, err
+	}
+
+	var response applicationResponse
+	_, err = c.do(req, &response)
+	return response.Application, err
+}

--- a/newrelic/application_instances.go
+++ b/newrelic/application_instances.go
@@ -12,16 +12,6 @@ type ApplicationInstance struct {
 	ApplicationSummary ApplicationSummary `json:"application_summary"`
 }
 
-// ApplicationSummary represents a rolling three-to-four-minute
-// average for application key values
-type ApplicationSummary struct {
-	InstanceCount int     `json:"instance_count"`
-	ResponseTime  float64 `json:"response_time"`
-	Throughput    float64 `json:"throughput"`
-	ErrorRate     float64 `json:"error_rate"`
-	ApdexScore    float64 `json:"apdex_score"`
-}
-
 type listInstancesResponse struct {
 	Instances []ApplicationInstance `json:"application_instances"`
 }

--- a/newrelic/application_summary.go
+++ b/newrelic/application_summary.go
@@ -1,0 +1,11 @@
+package newrelic
+
+// ApplicationSummary represents a rolling three-to-four-minute
+// average for application key values
+type ApplicationSummary struct {
+	InstanceCount int     `json:"instance_count"`
+	ResponseTime  float64 `json:"response_time"`
+	Throughput    float64 `json:"throughput"`
+	ErrorRate     float64 `json:"error_rate"`
+	ApdexScore    float64 `json:"apdex_score"`
+}


### PR DESCRIPTION
Collect application summary data. Application summary data is collected only if the instance count is greater than 0, otherwise it is ignored. 

According to NewRelic:
> The summary data represents a rolling average for key values. New Relic provides summary information for applications as a rolling three- to four-minute average.

The key values are apdex score, error rate, response time and throughput.

Scrape result:

<img width="908" alt="captura de tela 2018-01-19 as 14 31 03" src="https://user-images.githubusercontent.com/4973742/35160817-74d394bc-fd25-11e7-9e4f-6b5fdbf83f0a.png">

@ContaAzul/blackops @ContaAzul/gophers 
