### PR TITLE
Collect application metrics data concurrently

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,10 +9,11 @@ import (
 
 // Config represents the exporter configuration
 type Config struct {
-	Applications []application `yaml:"applications,omitempty"`
+	Applications []Application `yaml:"applications,omitempty"`
 }
 
-type application struct {
+// Application represents a NewRelic application scrape configuration
+type Application struct {
 	ID   int64  `yaml:"id,omitempty"`
 	Name string `yaml:"name,omitempty"`
 }


### PR DESCRIPTION
When the collector need to collect a a large number of applications it takes too much time to scrape all data:
```
# HELP newrelic_scrape_duration_seconds Time NewRelic scrape took in seconds
# TYPE newrelic_scrape_duration_seconds gauge
newrelic_scrape_duration_seconds 54.462175143
```

Changed to use goroutines to scrape this data concurrently instead of in a sequencial loop. This change improved a lot the performance:
```
# HELP newrelic_scrape_duration_seconds Time NewRelic scrape took in seconds
# TYPE newrelic_scrape_duration_seconds gauge
newrelic_scrape_duration_seconds 2.806703783
```

refs https://github.com/ContaAzul/BlackOps/issues/2146
@ContaAzul/sre 