### PR TITLE
Fixing goreleaser yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,16 +13,15 @@ builds:
   - CGO_ENABLED=0
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
-archive:
+archives:
   name_template: '{{ .Binary }}_{{ .Os }}_{{ .Arch }}'
 changelog:
   filters:
     exclude:
     - '^Merge (remote|branch|pull)'
 dockers:
-- image: caninjas/newrelic_exporter
-  tag_templates:
-  - '{{ .Tag }}'
-  - 'v{{ .Major }}'
-  - 'v{{ .Major }}.{{ .Minor }}'
-  - latest
+- image_templates:
+  - 'caninjas/newrelic_exporter:{{ .Tag }}'
+  - 'caninjas/newrelic_exporter:v{{ .Major }}'
+  - 'caninjas/newrelic_exporter:v{{ .Major }}.{{ .Minor }}'
+  - 'caninjas/newrelic_exporter:latest'


### PR DESCRIPTION
On the latest [goreleaser build](https://travis-ci.org/github/ContaAzul/newrelic_exporter/builds/711212251), this error showed up:

```
   • releasing...     
   • loading config file       file=.goreleaser.yml
   ⨯ release failed after 0.00s error=yaml: unmarshal errors:
  line 16: field archive not found in type config.Project
  line 23: field image not found in type config.Docker
  line 24: field tag_templates not found in type config.Docker
Script failed with status 1
```

Checking the [goreleaser docs](https://goreleaser.com/customization/docker/), some fields changed over time.