### PR TITLE
PLAT-20201 - chore: migra imagens do dockerhub para ECR

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,6 @@ changelog:
 dockers:
 - image_templates:
   - 'caninjas/newrelic_exporter:{{ .Tag }}'
-  - 'caninjas/newrelic_exporter:v{{ .Major }}'
-  - 'caninjas/newrelic_exporter:v{{ .Major }}.{{ .Minor }}'
-  - 'caninjas/newrelic_exporter:latest'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:v{{ .Major }}'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:v{{ .Major }}.{{ .Minor }}'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:latest'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,6 @@ changelog:
 dockers:
 - image_templates:
   - 'caninjas/newrelic_exporter:{{ .Tag }}'
-  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:v{{ .Major }}'
-  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:v{{ .Major }}.{{ .Minor }}'
-  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:latest'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:v{{ .Major }}'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:v{{ .Major }}.{{ .Minor }}'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:latest'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ applications:
 Or with docker:
 
 ```console
-docker run -p 9112:9112 -v /path/to/my/config.yml:/config.yml -e "NEWRELIC_API_KEY=${NEWRELIC_API_KEY}" 439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter
+docker run -p 9112:9112 -v /path/to/my/config.yml:/config.yml -e "NEWRELIC_API_KEY=${NEWRELIC_API_KEY}" 439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter
 ```
 
 ### Flags

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ applications:
 Or with docker:
 
 ```console
-docker run -p 9112:9112 -v /path/to/my/config.yml:/config.yml -e "NEWRELIC_API_KEY=${NEWRELIC_API_KEY}" caninjas/newrelic_exporter
+docker run -p 9112:9112 -v /path/to/my/config.yml:/config.yml -e "NEWRELIC_API_KEY=${NEWRELIC_API_KEY}" 439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter
 ```
 
 ### Flags


### PR DESCRIPTION
Migração automatizada: imagens `caninjas/*` → ECR.

## Substituições

### `.goreleaser.yml`

- `caninjas/newrelic_exporter` → `439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter` _(origem da tag: `fallback`)_
- `caninjas/newrelic_exporter:latest` → `439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:latest` _(origem da tag: `fallback`)_
- `caninjas/newrelic_exporter:v` → `439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter:v` _(origem da tag: `fallback`)_

### `README.md`

- `caninjas/newrelic_exporter` → `439291037095.dkr.ecr.us-east-2.amazonaws.com/base/newrelic_exporter` _(origem da tag: `fallback`)_

---

Gerada por `scripts/plan_caninjas_to_ecr_migration.py --create-prs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing configuration to new registry location.

* **Documentation**
  * Updated documentation with new Docker image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->