### PR TITLE
PLAT-20201 - chore: migra imagens do dockerhub para ECR

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ changelog:
     - '^Merge (remote|branch|pull)'
 dockers:
 - image_templates:
-  - 'caninjas/newrelic_exporter:{{ .Tag }}'
+  - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:{{ .Tag }}'
   - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:v{{ .Major }}'
   - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:v{{ .Major }}.{{ .Minor }}'
   - '439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/newrelic_exporter:latest'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker image publishing to AWS ECR registry, replacing the previous public registry distribution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ContaAzul/newrelic_exporter/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->